### PR TITLE
Fixed most of ticket rights.

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -85,6 +85,7 @@ Router::scope('/', function ($routes) {
     $routes->connect('/admin/edit/*', ['controller' => 'Users', 'action' => 'adminEdit']);
 
     $routes->connect('/tickets/add/*', ['controller' => 'Tickets', 'action' => 'add']);
+    $routes->connect('/tickets/delete/*', ['controller' => 'Tickets', 'action' => 'delete']);
     /**
      * ...and connect the rest of 'Pages' controller's URLs.
      */

--- a/src/Controller/ProjectsController.php
+++ b/src/Controller/ProjectsController.php
@@ -20,7 +20,7 @@ class ProjectsController extends AppController
             return true;
         }
 
-        // The owner of an article can edit and delete it.
+        // The owner of an project can edit and delete it.
         if (in_array($this->request->action, ['view', 'edit', 'delete'])){
             $projectId = (int)$this->request->params['pass'][0];
             if ($this->Projects->isOwnedBy($projectId, $user['id'])){

--- a/src/Controller/ProjectsController.php
+++ b/src/Controller/ProjectsController.php
@@ -32,7 +32,7 @@ class ProjectsController extends AppController
 
         // Check from the ProjectsUsers table if the person trying to access
         // is a moderator of that project.
-        if (in_array($this->request->action, ['view', 'edit'])){
+        if (in_array($this->request->action, ['view'])){
             $projectId = (int)$this->request->params['pass'][0];
             if ($ProjectsUsers->isModeratedBy($projectId, $user['id'])){
                 return true;

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -11,6 +11,47 @@ use App\Controller\AppController;
 class TicketsController extends AppController
 {
 
+    //Individual access rules to tickets functions (tickets/*).
+    public function isAuthorized($user)
+    {
+        // All registered users can view the index.
+        if (in_array($this->request->action, ['index'])){
+            return true;
+        }
+
+        // The owner of an project can do anything related to it's tickets.
+        
+        //if (in_array($this->request->action, ['view', 'edit', 'delete'])){
+        //    $projectId = (int)$this->request->params['pass'][0];
+        //    if ($this->Projects->isOwnedBy($projectId, $user['id'])){
+        //        return true;
+        //    }
+        //}
+
+        $TicketsUsers = TableRegistry::get('TicketsUsers');
+
+        // A moderator of a project can add and edit tickets.
+        
+        //if (in_array($this->request->action, ['add', 'edit'])){
+        //    $projectId = (int)$this->request->params['pass'][0];
+        //    if ($ProjectsUsers->isModeratedBy($projectId, $user['id'])){
+        //        return true;
+        //    }
+        //}
+
+        // Users assigned to tickets can view them.
+
+        if (in_array($this->request->action, ['view'])){
+            $ticketId = (int)$this->request->params['pass'][0];
+            if ($TicketsUsers->isAssignedTo($ticketId, $user['id'])){
+                return true;
+            }
+        }
+
+        // Otherwise default to Admin -> true, User -> false
+        return parent::isAuthorized($user);
+    }
+
     /**
      * Index method
      *

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -121,7 +121,15 @@ class TicketsController extends AppController
             ->where(['id' => $projectId]);
         $this->set('projectId', $projectId);
         $comments = $this->Tickets->Comments->find('list', ['limit' => 200]);
-        $users = $this->Tickets->Users->find('list', ['limit' => 200]);
+        
+        $users = $this->Tickets->Users
+            ->find('list', ['limit' => 200])
+            ->innerJoinWith(
+                'ProjectsUsers', function($q) use( &$projectId){
+                    return $q->where(['ProjectsUsers.project_id' => $projectId]);
+                }
+            );
+        
         $this->set(compact('ticket', 'projects', 'comments', 'users'));
         $this->set('_serialize', ['ticket']);
     }
@@ -157,7 +165,7 @@ class TicketsController extends AppController
 
         // Filter users by if they are involved in a project.
         $users = $this->Tickets->Users
-            ->find('list', ['limit' => 200, 'projectId' => $projectId])
+            ->find('list', ['limit' => 200])
             ->innerJoinWith(
                 'ProjectsUsers', function($q) use( &$projectId){
                     return $q->where(['ProjectsUsers.project_id' => $projectId]);

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -41,7 +41,6 @@ class TicketsController extends AppController
         //}
 
         // Users assigned to tickets can view them.
-
         if (in_array($this->request->action, ['view'])){
             $ticketId = (int)$this->request->params['pass'][0];
             if ($TicketsUsers->isAssignedTo($ticketId, $user['id'])){

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -20,31 +20,54 @@ class TicketsController extends AppController
             return true;
         }
 
-        // The owner of an project can do anything related to it's tickets.
-        
-        //if (in_array($this->request->action, ['view', 'edit', 'delete'])){
-        //    $projectId = (int)$this->request->params['pass'][0];
-        //    if ($this->Projects->isOwnedBy($projectId, $user['id'])){
-        //        return true;
-        //    }
-        //}
+        $Projects = TableRegistry::get('Projects');
+        $ProjectsUsers = TableRegistry::get('ProjectsUsers');
 
-        $TicketsUsers = TableRegistry::get('TicketsUsers');
-
-        // A moderator of a project can add and edit tickets.
-        
-        //if (in_array($this->request->action, ['add', 'edit'])){
-        //    $projectId = (int)$this->request->params['pass'][0];
-        //    if ($ProjectsUsers->isModeratedBy($projectId, $user['id'])){
-        //        return true;
-        //    }
-        //}
-
-        // Users assigned to tickets can view them.
-        if (in_array($this->request->action, ['view'])){
-            $ticketId = (int)$this->request->params['pass'][0];
-            if ($TicketsUsers->isAssignedTo($ticketId, $user['id'])){
+        if (in_array($this->request->action, ['add'])){
+            $projectId = (int)$this->request->params['pass'][0];
+            
+            if ($Projects->isOwnedBy($projectId, $user['id'])){
                 return true;
+            }
+
+            if ($ProjectsUsers->isModeratedBy($projectId, $user['id'])){
+                return true;
+            }
+        } else {
+
+            // Get the ticket id.
+            $ticketId = (int)$this->request->params['pass'][0];
+
+            $ProjectsTickets = TableRegistry::get('ProjectsTickets');
+        
+
+            // Lookup what project this ticket belongs to.
+            $projectId = $ProjectsTickets->find()
+                ->where(['ticket_id' => $ticketId])
+                ->first()['project_id'];
+
+            // The owner of an project can do anything related to it's tickets.
+            if (in_array($this->request->action, ['view', 'edit', 'delete'])){
+                if ($Projects->isOwnedBy($projectId, $user['id'])){
+                    return true;
+                }
+            }
+
+            // A moderator of a project can add and edit tickets.
+            if (in_array($this->request->action, ['add', 'view', 'edit'])){
+                if ($ProjectsUsers->isModeratedBy($projectId, $user['id'])){
+                    return true;
+                }
+            }
+
+            $TicketsUsers = TableRegistry::get('TicketsUsers');
+
+            // Users assigned to tickets can view them.
+            if (in_array($this->request->action, ['view'])){
+                $ticketId = (int)$this->request->params['pass'][0];
+                if ($TicketsUsers->isAssignedTo($ticketId, $user['id'])){
+                    return true;
+                }
             }
         }
 

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -154,21 +154,15 @@ class TicketsController extends AppController
         $projectId = $this->Tickets->ProjectsTickets->find()
             ->where(['ticket_id' => $id])
             ->first()['project_id'];
-        debug($id);
-        debug($projectId);
 
-
-        //$ProjectsUsers = TableRegistry::get('ProjectsUsers');
-
+        // Filter users by if they are involved in a project.
         $users = $this->Tickets->Users
             ->find('list', ['limit' => 200, 'projectId' => $projectId])
             ->innerJoinWith(
-                'ProjectsUsers', function($q){
-                    return $q;//->where(['ProjectsUsers.project_id' => $projectId]);
+                'ProjectsUsers', function($q) use( &$projectId){
+                    return $q->where(['ProjectsUsers.project_id' => $projectId]);
                 }
             );
-
-        debug($users); 
 
         $this->set(compact('ticket', 'projects', 'comments', 'users'));
         $this->set('_serialize', ['ticket']);

--- a/src/Model/Entity/TicketsUser.php
+++ b/src/Model/Entity/TicketsUser.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * TicketsUser Entity.
+ *
+ * @property int $ticket_id
+ * @property \App\Model\Entity\Ticket $ticket
+ * @property int $user_id
+ * @property \App\Model\Entity\User $user
+ */
+class TicketsUser extends Entity
+{
+
+    /**
+     * Fields that can be mass assigned using newEntity() or patchEntity().
+     *
+     * Note that when '*' is set to true, this allows all unspecified fields to
+     * be mass assigned. For security purposes, it is advised to set '*' to false
+     * (or remove it), and explicitly make individual fields accessible as needed.
+     *
+     * @var array
+     */
+    protected $_accessible = [
+        '*' => true,
+        'ticket_id' => false,
+        'user_id' => false,
+    ];
+}

--- a/src/Model/Table/TicketsUsersTable.php
+++ b/src/Model/Table/TicketsUsersTable.php
@@ -1,0 +1,63 @@
+<?php
+namespace App\Model\Table;
+
+use App\Model\Entity\TicketsUser;
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * TicketsUsers Model
+ *
+ * @property \Cake\ORM\Association\BelongsTo $Tickets
+ * @property \Cake\ORM\Association\BelongsTo $Users
+ */
+class TicketsUsersTable extends Table
+{
+
+    public function isAssignedTo($ticketId, $userId)
+    {
+        return $this->exists([
+            'ticket_id' => $ticketId, 
+            'user_id' => $userId]);
+    }
+
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->table('tickets_users');
+        $this->displayField('ticket_id');
+        $this->primaryKey(['ticket_id', 'user_id']);
+
+        $this->belongsTo('Tickets', [
+            'foreignKey' => 'ticket_id',
+            'joinType' => 'INNER'
+        ]);
+        $this->belongsTo('Users', [
+            'foreignKey' => 'user_id',
+            'joinType' => 'INNER'
+        ]);
+    }
+
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules)
+    {
+        $rules->add($rules->existsIn(['ticket_id'], 'Tickets'));
+        $rules->add($rules->existsIn(['user_id'], 'Users'));
+        return $rules;
+    }
+}

--- a/tests/Fixture/TicketsUsersFixture.php
+++ b/tests/Fixture/TicketsUsersFixture.php
@@ -1,0 +1,48 @@
+<?php
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * TicketsUsersFixture
+ *
+ */
+class TicketsUsersFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'ticket_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'user_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        '_indexes' => [
+            'user_ticket_key' => ['type' => 'index', 'columns' => ['user_id'], 'length' => []],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['ticket_id', 'user_id'], 'length' => []],
+            'ticket_user_key' => ['type' => 'foreign', 'columns' => ['ticket_id'], 'references' => ['tickets', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
+            'user_ticket_key' => ['type' => 'foreign', 'columns' => ['user_id'], 'references' => ['users', 'id'], 'update' => 'restrict', 'delete' => 'restrict', 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'ticket_id' => 1,
+            'user_id' => 1
+        ],
+    ];
+}

--- a/tests/TestCase/Model/Table/TicketsUsersTableTest.php
+++ b/tests/TestCase/Model/Table/TicketsUsersTableTest.php
@@ -1,0 +1,81 @@
+<?php
+namespace App\Test\TestCase\Model\Table;
+
+use App\Model\Table\TicketsUsersTable;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Model\Table\TicketsUsersTable Test Case
+ */
+class TicketsUsersTableTest extends TestCase
+{
+
+    /**
+     * Test subject
+     *
+     * @var \App\Model\Table\TicketsUsersTable
+     */
+    public $TicketsUsers;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'app.tickets_users',
+        'app.tickets',
+        'app.projects',
+        'app.users',
+        'app.projects_users',
+        'app.tickets_comments',
+        'app.tags',
+        'app.projects_tickets',
+        'app.comments'
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $config = TableRegistry::exists('TicketsUsers') ? [] : ['className' => 'App\Model\Table\TicketsUsersTable'];
+        $this->TicketsUsers = TableRegistry::get('TicketsUsers', $config);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->TicketsUsers);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initialize method
+     *
+     * @return void
+     */
+    public function testInitialize()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test buildRules method
+     *
+     * @return void
+     */
+    public function testBuildRules()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}


### PR DESCRIPTION
Ticket rights should now be working correctly. Owners can view/edit/add/delete tickets of their project, admins can view/edit/add tickets of their project and users can only view'tickets and only tickets that are assigned to them.

When adding/editing tickets user options are limited to the ones assigned to the project. A thing of note here is that if you want to assign the owner of a project to a ticket that owner has to be added as a user like everyone else. This is usefull if you want someone in charge of assigning users to a project that isn't solving tickets themselves.
